### PR TITLE
Enable slider scroll wheel on focus

### DIFF
--- a/freedom/script.js
+++ b/freedom/script.js
@@ -49,6 +49,32 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         handleAutoRecalculate();
       });
+
+      // Enable scroll wheel adjustment when the slider is focused
+      slider.addEventListener('wheel', (e) => {
+        if (document.activeElement !== slider) return;
+        e.preventDefault();
+
+        const stepAttr = slider.getAttribute('step');
+        const step = stepAttr ? parseFloat(stepAttr) : 1;
+        const minAttr = slider.getAttribute('min');
+        const maxAttr = slider.getAttribute('max');
+        const min = minAttr !== null ? parseFloat(minAttr) : -Infinity;
+        const max = maxAttr !== null ? parseFloat(maxAttr) : Infinity;
+
+        const direction = e.deltaY < 0 ? 1 : -1; // up = increase, down = decrease
+        const multiplier = e.shiftKey ? 10 : 1; // hold Shift for faster changes
+
+        const current = parseFloat(slider.value || '0');
+        const next = current + direction * step * multiplier;
+        const bounded = Math.max(min, Math.min(max, next));
+        const decimals = (String(step).split('.')[1] || '').length;
+        const rounded = Number(bounded.toFixed(decimals));
+
+        slider.value = rounded;
+        input.value = rounded;
+        handleAutoRecalculate();
+      }, { passive: false });
     }
   }
 


### PR DESCRIPTION
Enable scroll wheel adjustment for focused sliders to allow value changes without dragging.

When a slider is focused (via click or tab), scrolling up/down adjusts its value by its `step`. Holding Shift multiplies the change by 10. This also syncs the paired number input and triggers recalculations, similar to dragging the slider.

---
<a href="https://cursor.com/background-agent?bcId=bc-4d7fdd10-713a-47b8-8ce4-412b33e32238">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4d7fdd10-713a-47b8-8ce4-412b33e32238">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

